### PR TITLE
refactor: Update CORS allowed origins in settings.py

### DIFF
--- a/backend/mental_health_coach_backend/settings.py
+++ b/backend/mental_health_coach_backend/settings.py
@@ -59,6 +59,11 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
 ]
 
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:3000",
+    "https://budgieai.onrender.com",
+]
+
 ROOT_URLCONF = "mental_health_coach_backend.urls"
 
 TEMPLATES = [
@@ -131,7 +136,3 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-
-CORS_ALLOWED_ORIGINS = [
-    "http://localhost:3000",  # Our NextJS frontend URL
-]


### PR DESCRIPTION
Update the CORS_ALLOWED_ORIGINS list in the settings.py file to include "https://budgieai.onrender.com" as an allowed origin. This ensures that requests from the specified origin are allowed to access the backend API.